### PR TITLE
Add the shebang line for the perl interpreter

### DIFF
--- a/Scripts/MarkerAlignTrim.pl
+++ b/Scripts/MarkerAlignTrim.pl
@@ -1,3 +1,4 @@
+#!/usr/bin/perl
 # AMPHORA (version 2.0) An Automated Phylogenomic Inference Pipeline for Bacterial and Archaeal Sequences. 
 # Copyright 2011 by Martin Wu
  

--- a/Scripts/MarkerScanner.pl
+++ b/Scripts/MarkerScanner.pl
@@ -1,3 +1,4 @@
+#!/usr/bin/perl
 # AMPHORA (version 2.0) An Automated Phylogenomic Inference Pipeline for Bacterial and Archaeal Sequences. 
 # Copyright 2011 by Martin Wu
  

--- a/Scripts/Phylotyping.pl
+++ b/Scripts/Phylotyping.pl
@@ -1,3 +1,4 @@
+#!/usr/bin/perl
 # AMPHORA (version 2.0) An Automated Phylogenomic Inference Pipeline for Bacterial and Archaeal Sequences. 
 # Copyright 2011 by Martin Wu
  


### PR DESCRIPTION
Add a shebang line to the perl scripts so that users don't have to explicitly provide the interpreter on the command line.
